### PR TITLE
Update Signature.php

### DIFF
--- a/lib/ShippingEasy/Signature.php
+++ b/lib/ShippingEasy/Signature.php
@@ -46,7 +46,9 @@ class ShippingEasy_Signature
   {
     $parts = array($this->getHttpMethod());
     $parts[] = $this->getPath();
-    $parts[] = http_build_query($this->getParams());
+    
+    if (!empty($this->getParams()))
+      $parts[] = http_build_query($this->getParams());
 
     if ($this->getJsonBody() != "null")
       $parts[] = $this->getJsonBody();


### PR DESCRIPTION
Resolves problem with extra '&' being introduced when attempting to authenticate a callback from the server that has no parameters (other than `api_signature`)